### PR TITLE
Upgrade Biome to v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,20 +1,30 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
-    "organizeImports": {
-        "enabled": true
-    },
+    "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+    "assist": { "actions": { "source": { "organizeImports": "on" } } },
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true
+            "recommended": true,
+            "style": {
+                "noParameterAssign": "error",
+                "useAsConstAssertion": "error",
+                "useDefaultParameterLast": "error",
+                "useEnumInitializers": "error",
+                "useSelfClosingElements": "error",
+                "useSingleVarDeclarator": "error",
+                "noUnusedTemplateLiteral": "error",
+                "useNumberNamespace": "error",
+                "noInferrableTypes": "error",
+                "noUselessElse": "error"
+            }
         },
-        "ignore": ["cdk.out/**/*", "**/*.js", "**/*.d.ts", "**/*.json"]
+        "includes": ["**", "!**/cdk.out/**/*", "!**/*.js", "!**/*.d.ts", "!**/*.json"]
     },
     "formatter": {
         "enabled": true,
         "indentStyle": "space",
         "indentWidth": 4,
         "lineWidth": 120,
-        "ignore": ["cdk.out/**/*", "**/*.js", "**/*.d.ts", "**/*.json"]
+        "includes": ["**", "!**/cdk.out/**/*", "!**/*.js", "!**/*.d.ts", "!**/*.json"]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^16.5.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.9.4",
+        "@biomejs/biome": "2.0.5",
         "@types/jest": "^29.5.14",
         "@types/node": "22.14.1",
         "esbuild": "^0.25.2",
@@ -1220,11 +1220,11 @@
       "dev": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.5.tgz",
+      "integrity": "sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
       },
@@ -1236,24 +1236,25 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.0.5",
+        "@biomejs/cli-darwin-x64": "2.0.5",
+        "@biomejs/cli-linux-arm64": "2.0.5",
+        "@biomejs/cli-linux-arm64-musl": "2.0.5",
+        "@biomejs/cli-linux-x64": "2.0.5",
+        "@biomejs/cli-linux-x64-musl": "2.0.5",
+        "@biomejs/cli-win32-arm64": "2.0.5",
+        "@biomejs/cli-win32-x64": "2.0.5"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.5.tgz",
+      "integrity": "sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1263,13 +1264,14 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+      "integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1279,13 +1281,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+      "integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1295,13 +1298,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+      "integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1311,13 +1315,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+      "integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1327,13 +1332,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+      "integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1343,13 +1349,14 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+      "integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1359,13 +1366,14 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+      "integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.0.5",
     "@types/jest": "^29.5.14",
     "@types/node": "22.14.1",
     "esbuild": "^0.25.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function prepareContent(logContents: LogContent[]): ContentBlock[] {
      * - Removes any characters that are not alphanumeric, whitespace, hyphens, parentheses, or square brackets.
      * - Replaces multiple consecutive whitespace characters with a single space.
      */
-    const normalizeFileName = (name: string) => name.replace(/[^a-zA-Z0-9\s\-\(\)\[\]]/g, "").replace(/\s+/g, " ");
+    const normalizeFileName = (name: string) => name.replace(/[^a-zA-Z0-9\s\-()[\]]/g, "").replace(/\s+/g, " ");
 
     // Exclude logs whose csvContent starts with the NO_LOG_DATA_PREFIX so that dummy data is not sent to the AI
     const validLogs = logContents.filter((log) => !log.csvContent.trim().startsWith(NO_LOG_DATA_PREFIX));


### PR DESCRIPTION
This PR updates the project's code style tooling and related configuration:

- Upgrade `@biomejs/biome` and all CLI platform packages from v1.9.4 to v2.0.5
- Update `biome.json` to the new v2 schema and migrate settings accordingly
  - Add new style rules for stricter linting
  - Switch from `ignore` to `includes` patterns for linter and formatter
- Refresh `package-lock.json` to reflect dependency changes
